### PR TITLE
update list.html to fix summary

### DIFF
--- a/themes/hugo-creative-portfolio-theme/layouts/_default/list.html
+++ b/themes/hugo-creative-portfolio-theme/layouts/_default/list.html
@@ -1,3 +1,14 @@
 {{ define "main" }}
-  {{ partial "portfolio.html" . }}
+{{ with .Description }}
+  {{ $.Scratch.Set "summary" (markdownify .) }}
+{{ else }}
+  {{ $.Scratch.Set "summary"
+    ((delimit (findRE "(<p.*?>.*?</p>\\s*)+" .Content) "[&hellip;] ") |
+      plainify |
+      truncate (default 200 .Site.Params.summary_length)
+        (default " &hellip;" .Site.Params.text.truncated ) |
+      replaceRE "&amp;" "&" | safeHTML) }}
+{{ end }}
+{{ $.Scratch.Get "summary" }}
+{{ partial "portfolio.html" . }}
 {{ end }}


### PR DESCRIPTION
Referencing [this post](https://yihui.org/en/2017/08/hugo-post-summary/), there are necessary changes to the document template in list.html to fix native hugo summaries.